### PR TITLE
Use newer version of exometer core 1.4.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,3 @@
 {deps, [
-        {exometer_core, "1.0.0"}
+        {exometer_core, "1.4.0"}
        ]}.


### PR DESCRIPTION
I noticed that today version `1.5.0` was released and I will try to test it later. As of now we are using version `1.4.0` with my fork in production and I have not experienced any problems.